### PR TITLE
Modify weekend/weekday check to take into account 0 based index

### DIFF
--- a/AutoScaleALL.py
+++ b/AutoScaleALL.py
@@ -201,7 +201,7 @@ for resource in result.items:
     ActiveSchedule = ""
     if AnyDay in schedule:
         ActiveSchedule = schedule[AnyDay]
-    if DayOfWeek < 6 : #check for weekday / weekend
+    if DayOfWeek < 5 : #check for weekday / weekend
         if WeekDay in schedule:
             ActiveSchedule = schedule[WeekDay]
     else:


### PR DESCRIPTION
Hello @AnykeyNL first things first: thank you for you work!
While using your script I've noticed that my staging machines were not being shut down on Saturday for the whole 24 hours while instead everything was being shut down correctly on Sunday.

It seems that the DayOfWeek array is 0 based and so to fix my issue I just needed to decrease the number we are comparing the day to from 6 to 5.