### PR TITLE
Add support for Exadata Cluster VM Scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,19 +14,21 @@ The **AutoScaleALL** script: A single Auto Scaling script for all OCI resources 
 - Instance Pools: On/Off and Scaling (# of instances)
 - Database VMs: On/Off
 - Database Baremetal Servers: Scaling (# of CPUs)
-- Database Exadata CS: Scaling (# of CPUs)
+- Database Exadata CS: Scaling (# of CPUs)*
 - Autonomous Databases: On/Off and Scaling (# of CPUs)
 - Oracle Digital Assistant: On/Off
 - Oracle Analytics Cloud: On/Off and Scaling (between 2-8 oCPU and 10-12 oCPU)
 - Oracle Integration Service: On/Off
-- Load Balancer: Scaling (between 10, 100, 400, 8000 Mbps)*
-- MySQL Service: On/Off**
+- Load Balancer: Scaling (between 10, 100, 400, 8000 Mbps)**
+- MySQL Service: On/Off***
 - GoldenGate: On/Off
 
-*For the loadbalancer service, specify the number 10,100,400 or 8000 for each hour to set the correct shape.
+*Supports the original DB System resource model and the newer Cloud VM Cluster resource model (introduced in Nov 2020)
+
+**For the loadbalancer service, specify the number 10,100,400 or 8000 for each hour to set the correct shape.
 When changing shape, All existing connections to this load balancer will be reset during the update process and may take up to a minute, leading to potential connection loss. For non session persistent web based applications, I did not see any noticeable interruption or downtime in my own tests, but please test yourself!
 
-**MySQL Instances are not found by the search function :-( So a special routine is run to query them. 
+***MySQL Instances are not found by the search function :-( So a special routine is run to query them. 
 Also MySQL instances that are not running (Active state)) do not allow their tags to be changed/added/removed. 
 
 # Features


### PR DESCRIPTION
@AnykeyNL 

Oracle have introduced a new resource model for Exadata Cloud Systems.  In the new model, the DB system is split into two resources, the Cloud Exadata Infrastructure resource, and the Cloud VM Cluster resource.  Next month (May 15th 2021) support for the existing DbSystem API will end for Exadata Cloud Services.  Further details are available here:

https://docs.oracle.com/en-us/iaas/Content/Database/Concepts/exaflexsystem.htm#exaflexsystem_topic-resource_model

Deprecation of the API is mentioned here:
https://docs.oracle.com/en-us/iaas/api/#/en/database/20160918/DbSystem/

This pull request adds support for scaling the new Cloud VM Cluster resource and has been tested scaling up and down an Exadata system that has been migrated from the old resource model to the new model. Only one test is outstanding and that's scaling down to 0 (shut down) and then back up again. This can't be tested until I have a suitable window to take my system down. Hopefully within the next 48 hours.  This last test is to verify that when shutdown, the resource lifecycle_state still shows as available.

Regards
Richard