### PR TITLE
Add -override Option to Control a Group of Instances

### DIFF
--- a/AutoScaleALL.py
+++ b/AutoScaleALL.py
@@ -578,12 +578,13 @@ def autoscale_region(region):
                         ActiveSchedule = ("{},".format(schedulesize)*24)[:-1]
 
             if cmd.override:
-                ResourceOverrideTag = schedule[Override]
-                if cmd.override == "All" or cmd.override == ResourceOverrideTag:
-                    if cmd.action == "Up":
-                        ActiveSchedule = "1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1"
-                    if cmd.action == "Down":
-                        ActiveSchedule = "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0"
+                if Override in schedule:
+                    ResourceOverrideTag = schedule[Override]
+                    if cmd.override == "All" or cmd.override == ResourceOverrideTag:
+                        if cmd.action == "Up":
+                            ActiveSchedule = "1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1"
+                        if cmd.action == "Down":
+                            ActiveSchedule = "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0"
             
             #################################################################
             # Check if the active schedule contains exactly 24 numbers for each hour of the day

--- a/AutoScaleALL.py
+++ b/AutoScaleALL.py
@@ -46,6 +46,7 @@ Weekend = "Weekend"
 WeekDay = "WeekDay"
 DayOfMonth = "DayOfMonth"
 Version = "2022.11.05"
+Override = "Override"
 
 # ============== CONFIGURE THIS SECTION ======================
 # OCI Configuration

--- a/AutoScaleALL.py
+++ b/AutoScaleALL.py
@@ -22,6 +22,7 @@
 #   -printocid - print ocid of object
 #   -topic     - topic to sent summary
 #   -log       - send log output to OCI Logging service. Specify the Log OCID
+#   -ot        - override schedule based on a tag
 #   -h         - help
 #
 #################################################################################################################
@@ -575,6 +576,14 @@ def autoscale_region(region):
                     if int(day) == CurrentDayOfMonth:
                         ActiveSchedule = ("{},".format(schedulesize)*24)[:-1]
 
+            if cmd.override:
+                ResourceOverrideTag = schedule[Override]
+                if cmd.override == "All" or cmd.override == ResourceOverrideTag:
+                    if cmd.action == "Up":
+                        ActiveSchedule = "1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1"
+                    if cmd.action == "Down":
+                        ActiveSchedule = "0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0"
+            
             #################################################################
             # Check if the active schedule contains exactly 24 numbers for each hour of the day
             #################################################################
@@ -1541,6 +1550,7 @@ parser.add_argument('-ignoremysql', action='store_true', default=False, dest='ig
 parser.add_argument('-printocid', action='store_true', default=False, dest='print_ocid', help='Print OCID for resources')
 parser.add_argument('-topic', default="", dest='topic', help='Topic OCID to send summary in home region')
 parser.add_argument('-log', default="", dest='log', help='Log OCID to send log output to')
+parser.add_argument('-override', default="", dest='override', help='Override schedule based on a tag')
 
 cmd = parser.parse_args()
 if cmd.action != "All" and cmd.action != "Down" and cmd.action != "Up":

--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ A specific Nth day of month schedule overwrites a normal day of the month schedu
 
 ![Power Off Example DB VM](https://oc-blog.com/wp-content/uploads/2019/06/ScaleExampleDB.png)
 
+### Override Tag
+
+There may times when you want to force a group of servers to start or stop outside a predefined schedule. This could be a group of lab servers used for training that you want to control ad-hoc. You can add a defined tag `Schedule.Override` with any value to the instances and reference them with the `-override` parameter. 
+
+For example, you have the tag `Schedule.Override: labservers` set on instances, you can start those instances using this command.
+
+```bash
+python3 AutoScaleALL.py -a Up -override labservers
+```
+
 ### Changing the CPU and/or Memory Count of Compute Flex Shape
 If a value in the schedule is written as: (4:8) it will modify the CPU and Memory Count. The format should be (cpu:memory). 
 


### PR DESCRIPTION
There may times when you want to force a group of servers to start or stop outside a predefined schedule. This could be a group of lab servers used for training that you want to control ad-hoc. You can add a defined tag `Schedule.Override` with any value to the instances and reference them with the `-override` parameter. 

For example, you have the tag `Schedule.Override: labservers` set on instances, you can start those instances using this command.

```bash
python3 AutoScaleALL.py -a Up -override labservers
```